### PR TITLE
redirect cmake config output to a file

### DIFF
--- a/configure
+++ b/configure
@@ -22,5 +22,5 @@ cmake -DWITH_IPP=ON \
 	-DINSTALL_CREATE_DISTRIB=ON \
 	-DCMAKE_BUILD_TYPE=RELEASE \
 	-DCMAKE_INSTALL_PREFIX=${R_PACKAGE_DIR}/opencv/ \
-	../
+	../ > cmake_build.log
 cd ../


### PR DESCRIPTION
R CMD --as-cran, starting with R3.5 will generate warnings for all non-portable flags (https://github.com/wch/r-source/commit/2e80059) by parsing the R CMD check logs and identifying them. The argument is that, for example, one cannot know what -Werror does on all compilers (past, present or future) where it is supported (and -W flags do do different things on different compilers). By redirecting the cmake output to a file, the non-portable flags are excluded from the R CMD logs, thus no warnings are generated.